### PR TITLE
XML paintable fix

### DIFF
--- a/1.6/Defs/Buildings_Furniture.xml
+++ b/1.6/Defs/Buildings_Furniture.xml
@@ -19,7 +19,9 @@
     <designationCategory>Furniture</designationCategory>
     <uiIconOffset>(0, -0.04)</uiIconOffset>
     <minifiedDef>MinifiedThing</minifiedDef>
-	<paintable>true</paintable>
+	<building>
+		<paintable>true</paintable>
+	</building>
     <stuffCategories>
       <li>Metallic</li>
       <li>Stony</li>


### PR DESCRIPTION
Fixes the red error "XML error: <paintable>true</paintable. doesn't correspond to any field in type ThingDef. Context: <ThingDef"